### PR TITLE
Bump version to v1.1.0 and tweak styles

### DIFF
--- a/build/manifest.json
+++ b/build/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Tab Search",
-  "version": "1.0.16",
+  "version": "1.1.0",
   "description": "Search through all opened tabs quickly and easily",
   "permissions": [
     "tabs",

--- a/build/popup.css
+++ b/build/popup.css
@@ -5,9 +5,10 @@
 }
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-  color: #333;
+  color: #fff;
   width: 400px;
   height: 600px;
   overflow: hidden;
@@ -59,7 +60,9 @@ header h1 {
   font-size: 1.1rem;
   background: #fff;
   color: #222;
-  transition: border 0.2s, box-shadow 0.2s;
+  transition:
+    border 0.2s,
+    box-shadow 0.2s;
   outline: none;
   min-width: 0;
   box-sizing: border-box;
@@ -67,7 +70,7 @@ header h1 {
 
 #searchInput:focus {
   border-color: #667eea;
-  box-shadow: 0 0 0 2px rgba(102,126,234,0.15);
+  box-shadow: 0 0 0 2px rgba(102, 126, 234, 0.15);
 }
 
 .exact-match-btn {
@@ -83,9 +86,11 @@ header h1 {
   color: #667eea;
   font-weight: 500;
   cursor: pointer;
-  transition: background 0.2s, box-shadow 0.2s;
+  transition:
+    background 0.2s,
+    box-shadow 0.2s;
   outline: none;
-  box-shadow: 0 1px 4px rgba(102,126,234,0.08);
+  box-shadow: 0 1px 4px rgba(102, 126, 234, 0.08);
   z-index: 2;
   height: calc(100% - 0.6rem);
   min-width: 2rem;
@@ -100,7 +105,7 @@ header h1 {
   background: #667eea;
   color: #fff;
   border: 1.5px solid #667eea;
-  box-shadow: 0 2px 8px rgba(55,66,250,0.12);
+  box-shadow: 0 2px 8px rgba(55, 66, 250, 0.12);
 }
 
 .exact-match-btn:focus {
@@ -159,7 +164,11 @@ header h1 {
 }
 
 .tab-item.active {
-  background: linear-gradient(90deg, rgba(102, 126, 234, 0.1) 0%, rgba(102, 126, 234, 0.05) 100%);
+  background: linear-gradient(
+    90deg,
+    rgba(102, 126, 234, 0.1) 0%,
+    rgba(102, 126, 234, 0.05) 100%
+  );
   border-left-color: #667eea;
 }
 
@@ -237,7 +246,8 @@ header h1 {
   font-weight: 600;
 }
 
-.no-results, .loading {
+.no-results,
+.loading {
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -264,8 +274,12 @@ header h1 {
 }
 
 @keyframes spin {
-  0% { transform: rotate(0deg); }
-  100% { transform: rotate(360deg); }
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
 }
 
 footer {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Tab Search",
-  "version": "1.0.16",
+  "version": "1.1.0",
   "description": "Search through all opened tabs quickly and easily",
   "permissions": [
     "tabs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "laricercadielisa",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "description": "A Chrome extension for searching through all opened tabs",
     "type": "module",
     "scripts": {
@@ -32,6 +32,6 @@
         "browser",
         "productivity"
     ],
-    "author": "",
+    "author": "Massimiliano La Puma",
     "license": "MIT"
 }

--- a/version-log.txt
+++ b/version-log.txt
@@ -13,3 +13,4 @@
 2026-04-04T14:08:02.549Z: v1.0.14 - Build completed
 2026-04-04T14:12:45.873Z: v1.0.15 - Build completed
 2026-04-04T15:33:11.895Z: v1.0.16 - Build completed
+2026-04-04T16:42:47.116Z: v1.1.0 - Build completed


### PR DESCRIPTION
Bump extension version to 1.1.0 in manifest and build/manifest, and append new build entry to version-log. Update package.json version and author. Apply CSS cleanups and small visual tweaks in popup.css (font-family quoting, change body text to white, normalize rgba spacing, break long rules into multiple lines, adjust gradients/transitions/box-shadow formatting, and minor selector formatting).