### PR TITLE
feat: GitHub Pages landing page (#20)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,40 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,668 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Tab Search — instantly find any open Chrome tab by title or URL. Real-time search, keyboard navigation, dark mode." />
+  <meta property="og:title" content="Tab Search — Chrome Extension" />
+  <meta property="og:description" content="Instantly find any open Chrome tab. Real-time search, keyboard navigation, dark mode." />
+  <meta property="og:type" content="website" />
+  <title>Tab Search — Chrome Extension</title>
+  <style>
+    /* ── Reset & base ───────────────────────────────────────────── */
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --accent:      #2563eb;
+      --accent-dark: #1d4ed8;
+      --bg:          #ffffff;
+      --bg-card:     #f8fafc;
+      --bg-muted:    #f1f5f9;
+      --text:        #0f172a;
+      --text-secondary: #4a5568;
+      --border:      #e2e8f0;
+      --radius:      12px;
+      --shadow:      0 4px 24px rgba(15,23,42,.10);
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg:          #0f172a;
+        --bg-card:     #1e293b;
+        --bg-muted:    #1e293b;
+        --text:        #f1f5f9;
+        --text-secondary: #94a3b8;
+        --border:      #334155;
+        --shadow:      0 4px 24px rgba(0,0,0,.40);
+      }
+    }
+
+    html { scroll-behavior: smooth; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      line-height: 1.6;
+      font-size: 1rem;
+    }
+
+    img { max-width: 100%; display: block; }
+    a { color: var(--accent); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    a:focus-visible { outline: 3px solid var(--accent); outline-offset: 2px; border-radius: 4px; }
+
+    /* ── Layout helpers ─────────────────────────────────────────── */
+    .container { max-width: 960px; margin: 0 auto; padding: 0 24px; }
+
+    /* ── Navigation ─────────────────────────────────────────────── */
+    nav {
+      position: sticky;
+      top: 0;
+      z-index: 100;
+      background: var(--bg);
+      border-bottom: 1px solid var(--border);
+      padding: 0 24px;
+    }
+
+    nav .inner {
+      max-width: 960px;
+      margin: 0 auto;
+      height: 60px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    .nav-brand {
+      font-weight: 700;
+      font-size: 1.1rem;
+      color: var(--text);
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .nav-brand svg { flex-shrink: 0; }
+
+    nav ul {
+      list-style: none;
+      display: flex;
+      gap: 28px;
+    }
+
+    nav ul a {
+      font-size: .9rem;
+      font-weight: 500;
+      color: var(--text-secondary);
+    }
+
+    nav ul a:hover { color: var(--text); text-decoration: none; }
+
+    /* ── Hero ────────────────────────────────────────────────────── */
+    .hero {
+      padding: 80px 24px 64px;
+      text-align: center;
+    }
+
+    .badge {
+      display: inline-block;
+      background: #dbeafe;
+      color: #1e40af;
+      font-size: .8rem;
+      font-weight: 600;
+      padding: 4px 12px;
+      border-radius: 100px;
+      margin-bottom: 24px;
+      letter-spacing: .5px;
+      text-transform: uppercase;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      .badge { background: #1e3a8a; color: #93c5fd; }
+    }
+
+    .hero h1 {
+      font-size: clamp(2rem, 5vw, 3.2rem);
+      font-weight: 800;
+      line-height: 1.15;
+      letter-spacing: -.02em;
+      margin-bottom: 20px;
+    }
+
+    .hero h1 span { color: var(--accent); }
+
+    .hero p {
+      font-size: clamp(1rem, 2.5vw, 1.2rem);
+      color: var(--text-secondary);
+      max-width: 560px;
+      margin: 0 auto 36px;
+    }
+
+    .hero-cta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      justify-content: center;
+    }
+
+    .btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 12px 24px;
+      border-radius: 8px;
+      font-weight: 600;
+      font-size: .95rem;
+      transition: transform .15s, box-shadow .15s;
+      cursor: pointer;
+      border: none;
+    }
+
+    .btn:hover { transform: translateY(-1px); box-shadow: 0 6px 20px rgba(37,99,235,.3); text-decoration: none; }
+    .btn:active { transform: translateY(0); }
+
+    .btn-primary { background: var(--accent); color: #fff; }
+    .btn-primary:hover { background: var(--accent-dark); color: #fff; }
+
+    .btn-secondary {
+      background: var(--bg-muted);
+      color: var(--text);
+      border: 1px solid var(--border);
+    }
+
+    .btn-secondary:hover { box-shadow: 0 4px 12px rgba(0,0,0,.12); }
+
+    /* ── Popup mockup ────────────────────────────────────────────── */
+    .hero-mockup {
+      margin: 56px auto 0;
+      max-width: 360px;
+      background: #fff;
+      border-radius: 16px;
+      box-shadow: var(--shadow), 0 0 0 1px var(--border);
+      overflow: hidden;
+      font-size: .85rem;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      .hero-mockup { background: #1e293b; }
+    }
+
+    .mockup-bar {
+      background: var(--accent);
+      padding: 14px 16px 12px;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+    }
+
+    .mockup-bar input {
+      flex: 1;
+      background: rgba(255,255,255,.2);
+      border: none;
+      border-radius: 6px;
+      padding: 6px 10px;
+      color: #fff;
+      font-size: .85rem;
+      outline: none;
+    }
+
+    .mockup-bar input::placeholder { color: rgba(255,255,255,.7); }
+
+    .mockup-stats {
+      padding: 6px 16px;
+      font-size: .75rem;
+      color: var(--text-secondary);
+      border-bottom: 1px solid var(--border);
+    }
+
+    .mockup-list { padding: 4px 0; }
+
+    .mockup-item {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 10px 16px;
+      border-left: 3px solid transparent;
+      cursor: default;
+      border-bottom: 1px solid var(--border);
+    }
+
+    .mockup-item.active {
+      background: var(--bg-muted);
+      border-left-color: var(--accent);
+    }
+
+    .mockup-favicon {
+      width: 16px;
+      height: 16px;
+      border-radius: 3px;
+      flex-shrink: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 10px;
+    }
+
+    .mockup-item-text { flex: 1; overflow: hidden; }
+
+    .mockup-item-title {
+      font-size: .82rem;
+      font-weight: 500;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      color: var(--text);
+    }
+
+    .mockup-item-url {
+      font-size: .72rem;
+      color: var(--text-secondary);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    mark {
+      background: #fef08a;
+      color: #713f12;
+      border-radius: 2px;
+      padding: 0 1px;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      mark { background: #854d0e; color: #fef08a; }
+    }
+
+    /* ── Section shared ──────────────────────────────────────────── */
+    section { padding: 72px 24px; }
+    section:nth-child(even) { background: var(--bg-muted); }
+
+    .section-label {
+      display: block;
+      font-size: .78rem;
+      font-weight: 700;
+      letter-spacing: .08em;
+      text-transform: uppercase;
+      color: var(--accent);
+      margin-bottom: 10px;
+    }
+
+    section h2 {
+      font-size: clamp(1.5rem, 3vw, 2.2rem);
+      font-weight: 800;
+      letter-spacing: -.02em;
+      margin-bottom: 12px;
+    }
+
+    section .lead {
+      color: var(--text-secondary);
+      font-size: 1.05rem;
+      margin-bottom: 48px;
+      max-width: 540px;
+    }
+
+    /* ── Features grid ───────────────────────────────────────────── */
+    .features-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 20px;
+    }
+
+    .feature-card {
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 24px;
+      transition: box-shadow .2s;
+    }
+
+    .feature-card:hover { box-shadow: var(--shadow); }
+
+    .feature-icon {
+      width: 44px;
+      height: 44px;
+      background: #dbeafe;
+      border-radius: 10px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      margin-bottom: 16px;
+      font-size: 1.3rem;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      .feature-icon { background: #1e3a8a; }
+    }
+
+    .feature-card h3 { font-size: 1rem; font-weight: 700; margin-bottom: 6px; }
+    .feature-card p { font-size: .9rem; color: var(--text-secondary); }
+
+    /* ── Install steps ───────────────────────────────────────────── */
+    .steps { counter-reset: step; display: flex; flex-direction: column; gap: 20px; }
+
+    .step {
+      display: flex;
+      gap: 16px;
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 20px 24px;
+    }
+
+    .step-num {
+      counter-increment: step;
+      min-width: 36px;
+      height: 36px;
+      background: var(--accent);
+      color: #fff;
+      border-radius: 50%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-weight: 700;
+      font-size: .9rem;
+      flex-shrink: 0;
+    }
+
+    .step-num::after { content: counter(step); }
+
+    .step-body h3 { font-size: .95rem; font-weight: 700; margin-bottom: 4px; }
+    .step-body p { font-size: .88rem; color: var(--text-secondary); }
+    .step-body code {
+      background: var(--bg-muted);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      padding: 1px 5px;
+      font-size: .82rem;
+      font-family: 'SF Mono', 'Fira Code', monospace;
+    }
+
+    /* ── Author card ─────────────────────────────────────────────── */
+    .authors-grid {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 20px;
+    }
+
+    .author-card {
+      display: flex;
+      align-items: center;
+      gap: 16px;
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 20px 24px;
+      flex: 1;
+      min-width: 240px;
+    }
+
+    .author-avatar {
+      width: 56px;
+      height: 56px;
+      border-radius: 50%;
+      background: var(--bg-muted);
+      overflow: hidden;
+      flex-shrink: 0;
+    }
+
+    .author-avatar img { width: 100%; height: 100%; object-fit: cover; }
+
+    .author-info h3 { font-size: .95rem; font-weight: 700; margin-bottom: 2px; }
+    .author-info p { font-size: .85rem; color: var(--text-secondary); }
+    .author-info a { font-size: .82rem; }
+
+    /* ── Footer ──────────────────────────────────────────────────── */
+    footer {
+      background: var(--bg-card);
+      border-top: 1px solid var(--border);
+      padding: 36px 24px;
+      text-align: center;
+    }
+
+    footer .inner {
+      max-width: 960px;
+      margin: 0 auto;
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      justify-content: space-between;
+      gap: 16px;
+    }
+
+    footer p { font-size: .85rem; color: var(--text-secondary); }
+
+    footer .links {
+      display: flex;
+      gap: 20px;
+      list-style: none;
+    }
+
+    footer .links a { font-size: .85rem; color: var(--text-secondary); }
+    footer .links a:hover { color: var(--text); }
+
+    /* ── Responsive ──────────────────────────────────────────────── */
+    @media (max-width: 600px) {
+      nav ul { display: none; }
+      .hero { padding: 56px 16px 40px; }
+      section { padding: 48px 16px; }
+    }
+  </style>
+</head>
+<body>
+
+  <!-- ── Navigation ──────────────────────────────────────────────── -->
+  <nav aria-label="Main navigation">
+    <div class="inner">
+      <span class="nav-brand">
+        <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+          <rect width="24" height="24" rx="6" fill="#2563eb"/>
+          <circle cx="10" cy="10" r="5" stroke="#fff" stroke-width="2"/>
+          <line x1="14" y1="14" x2="20" y2="20" stroke="#fff" stroke-width="2" stroke-linecap="round"/>
+        </svg>
+        Tab Search
+      </span>
+      <ul>
+        <li><a href="#features">Features</a></li>
+        <li><a href="#install">Install</a></li>
+        <li><a href="#usage">Usage</a></li>
+        <li><a href="#authors">Authors</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <!-- ── Hero ────────────────────────────────────────────────────── -->
+  <header class="hero">
+    <div class="container">
+      <span class="badge">Chrome Extension · Manifest V3</span>
+      <h1>Find any <span>open tab</span><br>in an instant</h1>
+      <p>Tab Search lets you search through all your open Chrome tabs by title or URL — in real time, with full keyboard support.</p>
+      <div class="hero-cta">
+        <a class="btn btn-primary" href="https://github.com/massimilianolapuma/laricercadielisa/releases/latest" aria-label="Download latest release">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 2a10 10 0 1 0 0 20A10 10 0 0 0 12 2zm0 3l5 5h-3v4h-4v-4H7l5-5zm-5 10h10v2H7v-2z"/></svg>
+          Download
+        </a>
+        <a class="btn btn-secondary" href="https://github.com/massimilianolapuma/laricercadielisa" aria-label="View source on GitHub">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 2C6.48 2 2 6.48 2 12c0 4.42 2.87 8.17 6.84 9.49.5.09.68-.22.68-.48v-1.7c-2.78.6-3.37-1.34-3.37-1.34-.45-1.16-1.11-1.47-1.11-1.47-.91-.62.07-.61.07-.61 1 .07 1.53 1.03 1.53 1.03.89 1.52 2.34 1.08 2.91.83.09-.65.35-1.08.63-1.33-2.22-.25-4.56-1.11-4.56-4.95 0-1.09.39-1.98 1.03-2.68-.1-.25-.45-1.27.1-2.64 0 0 .84-.27 2.75 1.02A9.56 9.56 0 0 1 12 6.8c.85 0 1.71.11 2.51.33 1.91-1.29 2.75-1.02 2.75-1.02.55 1.37.2 2.39.1 2.64.64.7 1.03 1.59 1.03 2.68 0 3.85-2.34 4.7-4.57 4.95.36.31.68.92.68 1.85v2.74c0 .27.18.58.69.48A10.01 10.01 0 0 0 22 12c0-5.52-4.48-10-10-10z"/></svg>
+          View on GitHub
+        </a>
+      </div>
+
+      <!-- Popup mockup -->
+      <div class="hero-mockup" role="img" aria-label="Tab Search popup interface mockup">
+        <div class="mockup-bar">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <circle cx="10" cy="10" r="7" stroke="rgba(255,255,255,.8)" stroke-width="2"/>
+            <line x1="15.5" y1="15.5" x2="21" y2="21" stroke="rgba(255,255,255,.8)" stroke-width="2" stroke-linecap="round"/>
+          </svg>
+          <input type="text" placeholder="Search tabs…" value="github" readonly aria-label="Search field" />
+        </div>
+        <div class="mockup-stats">3 tabs found · 47 total</div>
+        <div class="mockup-list">
+          <div class="mockup-item active">
+            <div class="mockup-favicon" style="background:#f0fdf4" aria-hidden="true">🐙</div>
+            <div class="mockup-item-text">
+              <div class="mockup-item-title"><mark>GitHub</mark> — massimilianolapuma / laricercadielisa</div>
+              <div class="mockup-item-url">github.com/massimilianolapuma/laricercadielisa</div>
+            </div>
+          </div>
+          <div class="mockup-item">
+            <div class="mockup-favicon" style="background:#eff6ff" aria-hidden="true">📋</div>
+            <div class="mockup-item-text">
+              <div class="mockup-item-title">Pull requests · <mark>GitHub</mark></div>
+              <div class="mockup-item-url">github.com/pulls</div>
+            </div>
+          </div>
+          <div class="mockup-item">
+            <div class="mockup-favicon" style="background:#fefce8" aria-hidden="true">📊</div>
+            <div class="mockup-item-text">
+              <div class="mockup-item-title"><mark>GitHub</mark> Actions · CI Gate</div>
+              <div class="mockup-item-url">github.com/massimilianolapuma/laricercadielisa/actions</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <!-- ── Features ────────────────────────────────────────────────── -->
+  <section id="features">
+    <div class="container">
+      <span class="section-label">Features</span>
+      <h2>Everything you need to tame tab chaos</h2>
+      <p class="lead">No more hunting through dozens of tabs. Tab Search is fast, keyboard-first, and stays out of your way.</p>
+      <div class="features-grid">
+        <div class="feature-card">
+          <div class="feature-icon" aria-hidden="true">⚡</div>
+          <h3>Real-time search</h3>
+          <p>Results update instantly as you type — no delay, no button to press. Searches both tab titles and URLs.</p>
+        </div>
+        <div class="feature-card">
+          <div class="feature-icon" aria-hidden="true">⌨️</div>
+          <h3>Keyboard navigation</h3>
+          <p>Arrow keys to move, Enter to switch tab, Escape to close. Never touch the mouse if you don't want to.</p>
+        </div>
+        <div class="feature-card">
+          <div class="feature-icon" aria-hidden="true">🌙</div>
+          <h3>Dark mode</h3>
+          <p>Automatically follows your system preference. Supports light and dark themes with WCAG AA contrast.</p>
+        </div>
+        <div class="feature-card">
+          <div class="feature-icon" aria-hidden="true">♿</div>
+          <h3>Accessible</h3>
+          <p>Full ARIA support, screen reader compatible, minimum 4.5:1 contrast ratio on all text elements.</p>
+        </div>
+        <div class="feature-card">
+          <div class="feature-icon" aria-hidden="true">🗂️</div>
+          <h3>Tab management</h3>
+          <p>Switch to any tab, close individual tabs, or close all others with a single click. Confirmation for bulk actions.</p>
+        </div>
+        <div class="feature-card">
+          <div class="feature-icon" aria-hidden="true">🔒</div>
+          <h3>Privacy first</h3>
+          <p>No external servers. No analytics. All processing happens locally in your browser. Open source.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ── Install ──────────────────────────────────────────────────── -->
+  <section id="install">
+    <div class="container">
+      <span class="section-label">Installation</span>
+      <h2>Get started in 60 seconds</h2>
+      <p class="lead">Manual installation is quick. Chrome Web Store publishing is coming soon.</p>
+      <div class="steps">
+        <div class="step">
+          <span class="step-num" aria-label="Step 1"></span>
+          <div class="step-body">
+            <h3>Download the extension</h3>
+            <p>Grab the latest <code>.zip</code> from <a href="https://github.com/massimilianolapuma/laricercadielisa/releases/latest">GitHub Releases</a> and unzip it to a folder.</p>
+          </div>
+        </div>
+        <div class="step">
+          <span class="step-num" aria-label="Step 2"></span>
+          <div class="step-body">
+            <h3>Open Chrome Extensions</h3>
+            <p>Navigate to <code>chrome://extensions</code> in your browser.</p>
+          </div>
+        </div>
+        <div class="step">
+          <span class="step-num" aria-label="Step 3"></span>
+          <div class="step-body">
+            <h3>Enable Developer Mode</h3>
+            <p>Toggle the <strong>Developer mode</strong> switch in the top-right corner of the Extensions page.</p>
+          </div>
+        </div>
+        <div class="step">
+          <span class="step-num" aria-label="Step 4"></span>
+          <div class="step-body">
+            <h3>Load the extension</h3>
+            <p>Click <strong>Load unpacked</strong> and select the unzipped folder. Tab Search will appear in your toolbar immediately.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ── Usage ───────────────────────────────────────────────────── -->
+  <section id="usage">
+    <div class="container">
+      <span class="section-label">Usage</span>
+      <h2>How it works</h2>
+      <p class="lead">Click the Tab Search icon in your Chrome toolbar (or assign a keyboard shortcut in <code>chrome://extensions/shortcuts</code>) and start typing.</p>
+      <div class="features-grid">
+        <div class="feature-card">
+          <div class="feature-icon" aria-hidden="true">🔍</div>
+          <h3>Search</h3>
+          <p>Type any word from the tab's title or URL. Matching text is highlighted. Use the exact-match toggle for precise results.</p>
+        </div>
+        <div class="feature-card">
+          <div class="feature-icon" aria-hidden="true">🖱️</div>
+          <h3>Switch</h3>
+          <p>Click any result or press Enter on the keyboard-selected row to jump directly to that tab — even across different windows.</p>
+        </div>
+        <div class="feature-card">
+          <div class="feature-icon" aria-hidden="true">✂️</div>
+          <h3>Close</h3>
+          <p>Hit the × button on any row to close that tab, or use <strong>Close others</strong> to keep only the selected tab open.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ── Authors ──────────────────────────────────────────────────── -->
+  <section id="authors">
+    <div class="container">
+      <span class="section-label">Authors</span>
+      <h2>Built with care</h2>
+      <p class="lead">Tab Search is an open-source project. Contributions are welcome!</p>
+      <div class="authors-grid">
+        <div class="author-card">
+          <div class="author-avatar">
+            <img src="https://github.com/massimilianolapuma.png" alt="Massimiliano La Puma avatar" width="56" height="56" />
+          </div>
+          <div class="author-info">
+            <h3>Massimiliano La Puma</h3>
+            <p>Creator &amp; maintainer</p>
+            <a href="https://github.com/massimilianolapuma" target="_blank" rel="noopener noreferrer">@massimilianolapuma</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ── Footer ──────────────────────────────────────────────────── -->
+  <footer>
+    <div class="inner">
+      <p>© 2024–2026 Massimiliano La Puma · Released under the <a href="https://github.com/massimilianolapuma/laricercadielisa/blob/main/LICENSE">MIT License</a></p>
+      <ul class="links">
+        <li><a href="https://github.com/massimilianolapuma/laricercadielisa">GitHub</a></li>
+        <li><a href="https://github.com/massimilianolapuma/laricercadielisa/releases">Releases</a></li>
+        <li><a href="https://github.com/massimilianolapuma/laricercadielisa/issues">Issues</a></li>
+      </ul>
+    </div>
+  </footer>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

Adds a self-contained GitHub Pages landing page for the extension.

Closes #20

## Changes

- `docs/index.html` — Landing page with:
  - Hero section with interactive popup mockup
  - Features grid (real-time search, keyboard nav, dark mode, accessibility, tab management, privacy)
  - Step-by-step manual installation guide
  - Usage section
  - Authors/credits
  - Footer with repo links
  - Fully responsive, dark-mode aware, WCAG AA contrast compliant, no external dependencies

- `.github/workflows/pages.yml` — Deploys `docs/` to GitHub Pages automatically on push to `main`

## Notes
- No CDN dependencies — the page is fully self-contained
- Dark mode follows system preference via `prefers-color-scheme`
- All text meets minimum 4.5:1 contrast ratio (WCAG AA)
