### PR TITLE
feat(pages): add EN/IT i18n with system language detection

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -441,6 +441,19 @@
     footer .links a { font-size: .85rem; color: var(--text-secondary); }
     footer .links a:hover { color: var(--text); }
 
+    .lang-toggle {
+      background: var(--bg-muted);
+      border: 1px solid var(--border);
+      color: var(--text-secondary);
+      padding: 4px 12px;
+      border-radius: 6px;
+      font-size: .8rem;
+      font-weight: 600;
+      cursor: pointer;
+      transition: background .15s;
+    }
+    .lang-toggle:hover { background: var(--border); color: var(--text); }
+
     /* ── Responsive ──────────────────────────────────────────────── */
     @media (max-width: 600px) {
       nav ul { display: none; }
@@ -463,28 +476,29 @@
         Tab Search
       </span>
       <ul>
-        <li><a href="#features">Features</a></li>
-        <li><a href="#install">Install</a></li>
-        <li><a href="#usage">Usage</a></li>
-        <li><a href="#authors">Authors</a></li>
+        <li><a href="#features" data-i18n="navFeatures">Features</a></li>
+        <li><a href="#install" data-i18n="navInstall">Install</a></li>
+        <li><a href="#usage" data-i18n="navUsage">Usage</a></li>
+        <li><a href="#authors" data-i18n="navAuthors">Authors</a></li>
       </ul>
+      <button class="lang-toggle" id="langToggle" aria-label="Switch language">Italiano</button>
     </div>
   </nav>
 
   <!-- ── Hero ────────────────────────────────────────────────────── -->
   <header class="hero">
     <div class="container">
-      <span class="badge">Chrome Extension · Manifest V3</span>
-      <h1>Find any <span>open tab</span><br>in an instant</h1>
-      <p>Tab Search lets you search through all your open Chrome tabs by title or URL — in real time, with full keyboard support.</p>
+      <span class="badge" data-i18n="badge">Chrome Extension · Manifest V3</span>
+      <h1 data-i18n-html="heroTitle">Find any <span>open tab</span><br>in an instant</h1>
+      <p data-i18n="heroDesc">Tab Search lets you search through all your open Chrome tabs by title or URL — in real time, with full keyboard support.</p>
       <div class="hero-cta">
         <a class="btn btn-primary" href="https://github.com/massimilianolapuma/laricercadielisa/releases/latest" aria-label="Download latest release">
           <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 2a10 10 0 1 0 0 20A10 10 0 0 0 12 2zm0 3l5 5h-3v4h-4v-4H7l5-5zm-5 10h10v2H7v-2z"/></svg>
-          Download
+          <span data-i18n="downloadBtn">Download</span>
         </a>
         <a class="btn btn-secondary" href="https://github.com/massimilianolapuma/laricercadielisa" aria-label="View source on GitHub">
           <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 2C6.48 2 2 6.48 2 12c0 4.42 2.87 8.17 6.84 9.49.5.09.68-.22.68-.48v-1.7c-2.78.6-3.37-1.34-3.37-1.34-.45-1.16-1.11-1.47-1.11-1.47-.91-.62.07-.61.07-.61 1 .07 1.53 1.03 1.53 1.03.89 1.52 2.34 1.08 2.91.83.09-.65.35-1.08.63-1.33-2.22-.25-4.56-1.11-4.56-4.95 0-1.09.39-1.98 1.03-2.68-.1-.25-.45-1.27.1-2.64 0 0 .84-.27 2.75 1.02A9.56 9.56 0 0 1 12 6.8c.85 0 1.71.11 2.51.33 1.91-1.29 2.75-1.02 2.75-1.02.55 1.37.2 2.39.1 2.64.64.7 1.03 1.59 1.03 2.68 0 3.85-2.34 4.7-4.57 4.95.36.31.68.92.68 1.85v2.74c0 .27.18.58.69.48A10.01 10.01 0 0 0 22 12c0-5.52-4.48-10-10-10z"/></svg>
-          View on GitHub
+          <span data-i18n="githubBtn">View on GitHub</span>
         </a>
       </div>
 
@@ -497,7 +511,7 @@
           </svg>
           <input type="text" placeholder="Search tabs…" value="github" readonly aria-label="Search field" />
         </div>
-        <div class="mockup-stats">3 tabs found · 47 total</div>
+        <div class="mockup-stats" data-i18n="mockupStats">3 tabs found · 47 total</div>
         <div class="mockup-list">
           <div class="mockup-item active">
             <div class="mockup-favicon" style="background:#f0fdf4" aria-hidden="true">🐙</div>
@@ -528,39 +542,39 @@
   <!-- ── Features ────────────────────────────────────────────────── -->
   <section id="features">
     <div class="container">
-      <span class="section-label">Features</span>
-      <h2>Everything you need to tame tab chaos</h2>
-      <p class="lead">No more hunting through dozens of tabs. Tab Search is fast, keyboard-first, and stays out of your way.</p>
+      <span class="section-label" data-i18n="sectionFeaturesLabel">Features</span>
+      <h2 data-i18n="sectionFeaturesTitle">Everything you need to tame tab chaos</h2>
+      <p class="lead" data-i18n="sectionFeaturesLead">No more hunting through dozens of tabs. Tab Search is fast, keyboard-first, and stays out of your way.</p>
       <div class="features-grid">
         <div class="feature-card">
           <div class="feature-icon" aria-hidden="true">⚡</div>
-          <h3>Real-time search</h3>
-          <p>Results update instantly as you type — no delay, no button to press. Searches both tab titles and URLs.</p>
+          <h3 data-i18n="feature1Title">Real-time search</h3>
+          <p data-i18n="feature1Desc">Results update instantly as you type — no delay, no button to press. Searches both tab titles and URLs.</p>
         </div>
         <div class="feature-card">
           <div class="feature-icon" aria-hidden="true">⌨️</div>
-          <h3>Keyboard navigation</h3>
-          <p>Arrow keys to move, Enter to switch tab, Escape to close. Never touch the mouse if you don't want to.</p>
+          <h3 data-i18n="feature2Title">Keyboard navigation</h3>
+          <p data-i18n="feature2Desc">Arrow keys to move, Enter to switch tab, Escape to close. Never touch the mouse if you don't want to.</p>
         </div>
         <div class="feature-card">
           <div class="feature-icon" aria-hidden="true">🌙</div>
-          <h3>Dark mode</h3>
-          <p>Automatically follows your system preference. Supports light and dark themes with WCAG AA contrast.</p>
+          <h3 data-i18n="feature3Title">Dark mode</h3>
+          <p data-i18n="feature3Desc">Automatically follows your system preference. Supports light and dark themes with WCAG AA contrast.</p>
         </div>
         <div class="feature-card">
           <div class="feature-icon" aria-hidden="true">♿</div>
-          <h3>Accessible</h3>
-          <p>Full ARIA support, screen reader compatible, minimum 4.5:1 contrast ratio on all text elements.</p>
+          <h3 data-i18n="feature4Title">Accessible</h3>
+          <p data-i18n="feature4Desc">Full ARIA support, screen reader compatible, minimum 4.5:1 contrast ratio on all text elements.</p>
         </div>
         <div class="feature-card">
           <div class="feature-icon" aria-hidden="true">🗂️</div>
-          <h3>Tab management</h3>
-          <p>Switch to any tab, close individual tabs, or close all others with a single click. Confirmation for bulk actions.</p>
+          <h3 data-i18n="feature5Title">Tab management</h3>
+          <p data-i18n="feature5Desc">Switch to any tab, close individual tabs, or close all others with a single click. Confirmation for bulk actions.</p>
         </div>
         <div class="feature-card">
           <div class="feature-icon" aria-hidden="true">🔒</div>
-          <h3>Privacy first</h3>
-          <p>No external servers. No analytics. All processing happens locally in your browser. Open source.</p>
+          <h3 data-i18n="feature6Title">Privacy first</h3>
+          <p data-i18n="feature6Desc">No external servers. No analytics. All processing happens locally in your browser. Open source.</p>
         </div>
       </div>
     </div>
@@ -569,36 +583,36 @@
   <!-- ── Install ──────────────────────────────────────────────────── -->
   <section id="install">
     <div class="container">
-      <span class="section-label">Installation</span>
-      <h2>Get started in 60 seconds</h2>
-      <p class="lead">Manual installation is quick. Chrome Web Store publishing is coming soon.</p>
+      <span class="section-label" data-i18n="sectionInstallLabel">Installation</span>
+      <h2 data-i18n="sectionInstallTitle">Get started in 60 seconds</h2>
+      <p class="lead" data-i18n="sectionInstallLead">Manual installation is quick. Chrome Web Store publishing is coming soon.</p>
       <div class="steps">
         <div class="step">
           <span class="step-num" aria-label="Step 1"></span>
           <div class="step-body">
-            <h3>Download the extension</h3>
-            <p>Grab the latest <code>.zip</code> from <a href="https://github.com/massimilianolapuma/laricercadielisa/releases/latest">GitHub Releases</a> and unzip it to a folder.</p>
+            <h3 data-i18n="step1Title">Download the extension</h3>
+            <p data-i18n-html="step1Desc">Grab the latest <code>.zip</code> from <a href="https://github.com/massimilianolapuma/laricercadielisa/releases/latest">GitHub Releases</a> and unzip it to a folder.</p>
           </div>
         </div>
         <div class="step">
           <span class="step-num" aria-label="Step 2"></span>
           <div class="step-body">
-            <h3>Open Chrome Extensions</h3>
-            <p>Navigate to <code>chrome://extensions</code> in your browser.</p>
+            <h3 data-i18n="step2Title">Open Chrome Extensions</h3>
+            <p data-i18n-html="step2Desc">Navigate to <code>chrome://extensions</code> in your browser.</p>
           </div>
         </div>
         <div class="step">
           <span class="step-num" aria-label="Step 3"></span>
           <div class="step-body">
-            <h3>Enable Developer Mode</h3>
-            <p>Toggle the <strong>Developer mode</strong> switch in the top-right corner of the Extensions page.</p>
+            <h3 data-i18n="step3Title">Enable Developer Mode</h3>
+            <p data-i18n-html="step3Desc">Toggle the <strong>Developer mode</strong> switch in the top-right corner of the Extensions page.</p>
           </div>
         </div>
         <div class="step">
           <span class="step-num" aria-label="Step 4"></span>
           <div class="step-body">
-            <h3>Load the extension</h3>
-            <p>Click <strong>Load unpacked</strong> and select the unzipped folder. Tab Search will appear in your toolbar immediately.</p>
+            <h3 data-i18n="step4Title">Load the extension</h3>
+            <p data-i18n-html="step4Desc">Click <strong>Load unpacked</strong> and select the unzipped folder. Tab Search will appear in your toolbar immediately.</p>
           </div>
         </div>
       </div>
@@ -608,24 +622,24 @@
   <!-- ── Usage ───────────────────────────────────────────────────── -->
   <section id="usage">
     <div class="container">
-      <span class="section-label">Usage</span>
-      <h2>How it works</h2>
-      <p class="lead">Click the Tab Search icon in your Chrome toolbar (or assign a keyboard shortcut in <code>chrome://extensions/shortcuts</code>) and start typing.</p>
+      <span class="section-label" data-i18n="sectionUsageLabel">Usage</span>
+      <h2 data-i18n="sectionUsageTitle">How it works</h2>
+      <p class="lead" data-i18n-html="sectionUsageLead">Click the Tab Search icon in your Chrome toolbar (or assign a keyboard shortcut in <code>chrome://extensions/shortcuts</code>) and start typing.</p>
       <div class="features-grid">
         <div class="feature-card">
           <div class="feature-icon" aria-hidden="true">🔍</div>
-          <h3>Search</h3>
-          <p>Type any word from the tab's title or URL. Matching text is highlighted. Use the exact-match toggle for precise results.</p>
+          <h3 data-i18n="usage1Title">Search</h3>
+          <p data-i18n="usage1Desc">Type any word from the tab's title or URL. Matching text is highlighted. Use the exact-match toggle for precise results.</p>
         </div>
         <div class="feature-card">
           <div class="feature-icon" aria-hidden="true">🖱️</div>
-          <h3>Switch</h3>
-          <p>Click any result or press Enter on the keyboard-selected row to jump directly to that tab — even across different windows.</p>
+          <h3 data-i18n="usage2Title">Switch</h3>
+          <p data-i18n="usage2Desc">Click any result or press Enter on the keyboard-selected row to jump directly to that tab — even across different windows.</p>
         </div>
         <div class="feature-card">
           <div class="feature-icon" aria-hidden="true">✂️</div>
-          <h3>Close</h3>
-          <p>Hit the × button on any row to close that tab, or use <strong>Close others</strong> to keep only the selected tab open.</p>
+          <h3 data-i18n="usage3Title">Close</h3>
+          <p data-i18n-html="usage3Desc">Hit the × button on any row to close that tab, or use <strong>Close others</strong> to keep only the selected tab open.</p>
         </div>
       </div>
     </div>
@@ -634,9 +648,9 @@
   <!-- ── Authors ──────────────────────────────────────────────────── -->
   <section id="authors">
     <div class="container">
-      <span class="section-label">Authors</span>
-      <h2>Built with care</h2>
-      <p class="lead">Tab Search is an open-source project. Contributions are welcome!</p>
+      <span class="section-label" data-i18n="sectionAuthorsLabel">Authors</span>
+      <h2 data-i18n="sectionAuthorsTitle">Built with care</h2>
+      <p class="lead" data-i18n="sectionAuthorsLead">Tab Search is an open-source project. Contributions are welcome!</p>
       <div class="authors-grid">
         <div class="author-card">
           <div class="author-avatar">
@@ -644,7 +658,7 @@
           </div>
           <div class="author-info">
             <h3>Massimiliano La Puma</h3>
-            <p>Creator &amp; maintainer</p>
+            <p data-i18n="authorRole">Creator &amp; maintainer</p>
             <a href="https://github.com/massimilianolapuma" target="_blank" rel="noopener noreferrer">@massimilianolapuma</a>
           </div>
         </div>
@@ -655,14 +669,151 @@
   <!-- ── Footer ──────────────────────────────────────────────────── -->
   <footer>
     <div class="inner">
-      <p>© 2024–2026 Massimiliano La Puma · Released under the <a href="https://github.com/massimilianolapuma/laricercadielisa/blob/main/LICENSE">MIT License</a></p>
+      <p data-i18n-html="footerCopyright">© 2024–2026 Massimiliano La Puma · Released under the <a href="https://github.com/massimilianolapuma/laricercadielisa/blob/main/LICENSE">MIT License</a></p>
       <ul class="links">
-        <li><a href="https://github.com/massimilianolapuma/laricercadielisa">GitHub</a></li>
-        <li><a href="https://github.com/massimilianolapuma/laricercadielisa/releases">Releases</a></li>
-        <li><a href="https://github.com/massimilianolapuma/laricercadielisa/issues">Issues</a></li>
+        <li><a href="https://github.com/massimilianolapuma/laricercadielisa" data-i18n="footerGithub">GitHub</a></li>
+        <li><a href="https://github.com/massimilianolapuma/laricercadielisa/releases" data-i18n="footerReleases">Releases</a></li>
+        <li><a href="https://github.com/massimilianolapuma/laricercadielisa/issues" data-i18n="footerIssues">Issues</a></li>
       </ul>
     </div>
   </footer>
 
+  <script>
+    const TRANSLATIONS = {
+      en: {
+        badge: `Chrome Extension · Manifest V3`,
+        heroTitle: `Find any <span>open tab</span><br>in an instant`,
+        heroDesc: `Tab Search lets you search through all your open Chrome tabs by title or URL — in real time, with full keyboard support.`,
+        downloadBtn: `Download`,
+        githubBtn: `View on GitHub`,
+        mockupStats: `3 tabs found · 47 total`,
+        navFeatures: `Features`, navInstall: `Install`, navUsage: `Usage`, navAuthors: `Authors`,
+        langToggle: `Italiano`,
+        sectionFeaturesLabel: `Features`,
+        sectionFeaturesTitle: `Everything you need to tame tab chaos`,
+        sectionFeaturesLead: `No more hunting through dozens of tabs. Tab Search is fast, keyboard-first, and stays out of your way.`,
+        feature1Title: `Real-time search`,
+        feature1Desc: `Results update instantly as you type — no delay, no button to press. Searches both tab titles and URLs.`,
+        feature2Title: `Keyboard navigation`,
+        feature2Desc: `Arrow keys to move, Enter to switch tab, Escape to close. Never touch the mouse if you don't want to.`,
+        feature3Title: `Dark mode`,
+        feature3Desc: `Automatically follows your system preference. Supports light and dark themes with WCAG AA contrast.`,
+        feature4Title: `Accessible`,
+        feature4Desc: `Full ARIA support, screen reader compatible, minimum 4.5:1 contrast ratio on all text elements.`,
+        feature5Title: `Tab management`,
+        feature5Desc: `Switch to any tab, close individual tabs, or close all others with a single click. Confirmation for bulk actions.`,
+        feature6Title: `Privacy first`,
+        feature6Desc: `No external servers. No analytics. All processing happens locally in your browser. Open source.`,
+        sectionInstallLabel: `Installation`,
+        sectionInstallTitle: `Get started in 60 seconds`,
+        sectionInstallLead: `Manual installation is quick. Chrome Web Store publishing is coming soon.`,
+        step1Title: `Download the extension`,
+        step1Desc: `Grab the latest <code>.zip</code> from <a href="https://github.com/massimilianolapuma/laricercadielisa/releases/latest">GitHub Releases</a> and unzip it to a folder.`,
+        step2Title: `Open Chrome Extensions`,
+        step2Desc: `Navigate to <code>chrome://extensions</code> in your browser.`,
+        step3Title: `Enable Developer Mode`,
+        step3Desc: `Toggle the <strong>Developer mode</strong> switch in the top-right corner of the Extensions page.`,
+        step4Title: `Load the extension`,
+        step4Desc: `Click <strong>Load unpacked</strong> and select the unzipped folder. Tab Search will appear in your toolbar immediately.`,
+        sectionUsageLabel: `Usage`,
+        sectionUsageTitle: `How it works`,
+        sectionUsageLead: `Click the Tab Search icon in your Chrome toolbar (or assign a keyboard shortcut in <code>chrome://extensions/shortcuts</code>) and start typing.`,
+        usage1Title: `Search`,
+        usage1Desc: `Type any word from the tab's title or URL. Matching text is highlighted. Use the exact-match toggle for precise results.`,
+        usage2Title: `Switch`,
+        usage2Desc: `Click any result or press Enter on the keyboard-selected row to jump directly to that tab — even across different windows.`,
+        usage3Title: `Close`,
+        usage3Desc: `Hit the × button on any row to close that tab, or use <strong>Close others</strong> to keep only the selected tab open.`,
+        sectionAuthorsLabel: `Authors`,
+        sectionAuthorsTitle: `Built with care`,
+        sectionAuthorsLead: `Tab Search is an open-source project. Contributions are welcome!`,
+        authorRole: `Creator & maintainer`,
+        footerCopyright: `© 2024–2026 Massimiliano La Puma · Released under the <a href="https://github.com/massimilianolapuma/laricercadielisa/blob/main/LICENSE">MIT License</a>`,
+        footerGithub: `GitHub`,
+        footerReleases: `Releases`,
+        footerIssues: `Issues`,
+        pageTitle: `Tab Search — Chrome Extension`,
+      },
+      it: {
+        badge: `Estensione Chrome · Manifest V3`,
+        heroTitle: `Trova qualsiasi <span>scheda aperta</span><br>in un istante`,
+        heroDesc: `Tab Search ti permette di cercare tra tutte le schede Chrome aperte per titolo o URL — in tempo reale, con supporto completo da tastiera.`,
+        downloadBtn: `Scarica`,
+        githubBtn: `Vedi su GitHub`,
+        mockupStats: `3 schede trovate · 47 totali`,
+        navFeatures: `Funzionalità`, navInstall: `Installazione`, navUsage: `Utilizzo`, navAuthors: `Autori`,
+        langToggle: `English`,
+        sectionFeaturesLabel: `Funzionalità`,
+        sectionFeaturesTitle: `Tutto il necessario per domare il caos delle schede`,
+        sectionFeaturesLead: `Basta cercare tra decine di schede. Tab Search è veloce, pensato per la tastiera e non si mette mai in mezzo.`,
+        feature1Title: `Ricerca in tempo reale`,
+        feature1Desc: `I risultati si aggiornano istantaneamente mentre scrivi — nessun ritardo, nessun pulsante da premere. Cerca sia nei titoli che negli URL.`,
+        feature2Title: `Navigazione da tastiera`,
+        feature2Desc: `Frecce per spostarsi, Invio per cambiare scheda, Esc per chiudere. Non toccare mai il mouse se non vuoi.`,
+        feature3Title: `Modalità scura`,
+        feature3Desc: `Segue automaticamente le preferenze di sistema. Supporta i temi chiaro e scuro con contrasto WCAG AA.`,
+        feature4Title: `Accessibile`,
+        feature4Desc: `Supporto ARIA completo, compatibile con screen reader, rapporto di contrasto minimo 4.5:1 su tutti gli elementi di testo.`,
+        feature5Title: `Gestione schede`,
+        feature5Desc: `Passa a qualsiasi scheda, chiudi singole schede o chiudi tutte le altre con un clic. Conferma per le azioni di massa.`,
+        feature6Title: `Privacy prima di tutto`,
+        feature6Desc: `Nessun server esterno. Nessuna analisi. Tutto viene elaborato localmente nel browser. Open source.`,
+        sectionInstallLabel: `Installazione`,
+        sectionInstallTitle: `Inizia in 60 secondi`,
+        sectionInstallLead: `L'installazione manuale è rapida. La pubblicazione nel Chrome Web Store è in arrivo.`,
+        step1Title: `Scarica l'estensione`,
+        step1Desc: `Prendi l'ultimo <code>.zip</code> da <a href="https://github.com/massimilianolapuma/laricercadielisa/releases/latest">GitHub Releases</a> e decomprimilo in una cartella.`,
+        step2Title: `Apri le Estensioni Chrome`,
+        step2Desc: `Naviga su <code>chrome://extensions</code> nel browser.`,
+        step3Title: `Abilita la modalità sviluppatore`,
+        step3Desc: `Attiva l'interruttore <strong>Modalità sviluppatore</strong> nell'angolo in alto a destra della pagina Estensioni.`,
+        step4Title: `Carica l'estensione`,
+        step4Desc: `Clicca su <strong>Carica non pacchettizzata</strong> e seleziona la cartella decompressa. Tab Search apparirà immediatamente nella barra degli strumenti.`,
+        sectionUsageLabel: `Utilizzo`,
+        sectionUsageTitle: `Come funziona`,
+        sectionUsageLead: `Clicca sull'icona Tab Search nella barra degli strumenti di Chrome (o assegna una scorciatoia da tastiera in <code>chrome://extensions/shortcuts</code>) e inizia a digitare.`,
+        usage1Title: `Cerca`,
+        usage1Desc: `Digita qualsiasi parola dal titolo o URL della scheda. Il testo corrispondente viene evidenziato. Usa il selettore corrispondenza esatta per risultati precisi.`,
+        usage2Title: `Passa alla scheda`,
+        usage2Desc: `Clicca su qualsiasi risultato o premi Invio sulla riga selezionata da tastiera per passare direttamente a quella scheda — anche tra diverse finestre.`,
+        usage3Title: `Chiudi`,
+        usage3Desc: `Premi il pulsante × su qualsiasi riga per chiudere quella scheda, oppure usa <strong>Chiudi altre</strong> per tenere aperta solo la scheda selezionata.`,
+        sectionAuthorsLabel: `Autori`,
+        sectionAuthorsTitle: `Costruito con cura`,
+        sectionAuthorsLead: `Tab Search è un progetto open-source. I contributi sono benvenuti!`,
+        authorRole: `Creatore e manutentore`,
+        footerCopyright: `© 2024–2026 Massimiliano La Puma · Rilasciato con <a href="https://github.com/massimilianolapuma/laricercadielisa/blob/main/LICENSE">Licenza MIT</a>`,
+        footerGithub: `GitHub`,
+        footerReleases: `Release`,
+        footerIssues: `Segnalazioni`,
+        pageTitle: `Tab Search — Estensione Chrome`,
+      }
+    };
+
+    const detectLang = () => localStorage.getItem('tab-search-lang') || (navigator.language?.startsWith('it') ? 'it' : 'en');
+
+    const applyI18n = lang => {
+      const t = TRANSLATIONS[lang] || TRANSLATIONS.en;
+      document.documentElement.lang = lang;
+      document.querySelectorAll('[data-i18n]').forEach(el => {
+        if (t[el.dataset.i18n]) el.textContent = t[el.dataset.i18n];
+      });
+      document.querySelectorAll('[data-i18n-html]').forEach(el => {
+        if (t[el.dataset.i18nHtml]) el.innerHTML = t[el.dataset.i18nHtml];
+      });
+      document.title = t.pageTitle || 'Tab Search — Chrome Extension';
+      const btn = document.getElementById('langToggle');
+      if (btn) btn.textContent = t.langToggle;
+    };
+
+    let currentLang = detectLang();
+    applyI18n(currentLang);
+
+    document.getElementById('langToggle').addEventListener('click', () => {
+      currentLang = currentLang === 'en' ? 'it' : 'en';
+      localStorage.setItem('tab-search-lang', currentLang);
+      applyI18n(currentLang);
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Adds EN/IT internationalisation to the GitHub Pages landing page (`docs/index.html`), with automatic language detection and a manual toggle button.

Closes #23

## Changes

### `docs/index.html`
- Added `.lang-toggle` CSS styles for the toggle button
- Added `<button id="langToggle">` in the nav bar to switch between EN and IT
- Added `data-i18n` and `data-i18n-html` attributes to all user-facing text nodes (40+ elements across hero, features, install steps, usage cards, authors, and footer)
- Added an inline `<script>` block with:
  - `TRANSLATIONS` object containing the full EN and IT strings
  - `detectLang()` — reads `localStorage` preference or falls back to `navigator.language`
  - `applyI18n()` — applies translations to all `data-i18n*` elements
  - Toggle click handler — switches language and persists the choice in `localStorage`

## Behaviour

- On first visit the page language matches the browser's system language (IT if Italian, EN otherwise)
- Clicking the "EN / IT" button in the nav instantly switches all text
- The chosen language is remembered across page reloads via `localStorage`