### PR TITLE
fix(release): include _locales in extension package

### DIFF
--- a/.github/workflows/rel-release.yml
+++ b/.github/workflows/rel-release.yml
@@ -78,6 +78,7 @@ jobs:
           mkdir -p _pkg
           cp manifest.json popup.html popup.js popup.css popup-init.js README.md LICENSE _pkg/
           cp -r icons _pkg/
+          cp -r _locales _pkg/
           cd _pkg
           zip -r "../laricercadielisa-${VERSION}.zip" .
           cd ..


### PR DESCRIPTION
## Problem

The v1.5.1 release ZIP was missing the `_locales/` directory, causing the Chrome extension error:

```
Error: Default locale was specified, but _locales subtree is missing.
```

## Root Cause

The `Create extension package` step in `rel-release.yml` explicitly copied `icons/` but never copied `_locales/`:

```yaml
cp -r icons _pkg/
# _locales was never copied → missing from ZIP
```

Note: `build.js` (fixed in PR #27) already had `_locales` in `directoriesToCopy`, but the release workflow does **not** invoke `build.js` — it packages the extension with manual `cp` commands.

## Fix

Added one line after `cp -r icons _pkg/`:

```yaml
cp -r _locales _pkg/
```

## Testing

The next tagged release will include `_locales/` in the ZIP, resolving the Chrome load error.

Closes #28