### PR TITLE
fix(ci): add _locales to release package; fix checkout SHAs in rel-direct-tag.yml

### DIFF
--- a/.github/workflows/rel-direct-tag.yml
+++ b/.github/workflows/rel-direct-tag.yml
@@ -69,7 +69,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
               with:
                   # workflow_run context: usa il SHA del commit che ha triggerato CI,
                   # non il HEAD corrente del default branch.
@@ -122,7 +122,7 @@ jobs:
             #       private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
 
             - name: Checkout
-              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
               with:
                   # workflow_run context: usa il SHA del commit che ha triggerato CI.
                   # Fallback a github.sha per workflow_dispatch.
@@ -172,7 +172,7 @@ jobs:
 
         steps:
             - name: Checkout tag
-              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
               with:
                   ref: v${{ needs.detect.outputs.release-as }}
                   fetch-depth: 0
@@ -204,6 +204,10 @@ jobs:
                   mkdir -p _pkg
                   cp manifest.json popup.html popup.js popup.css popup-init.js README.md LICENSE _pkg/
                   cp -r icons _pkg/
+                  [ -d _locales ] || { echo "_locales missing — abort"; exit 1; }
+                  cp -r _locales _pkg/
+                  [ -f _pkg/_locales/en/messages.json ] || { echo "_locales/en/messages.json missing"; exit 1; }
+                  [ -f _pkg/_locales/it/messages.json ] || { echo "_locales/it/messages.json missing"; exit 1; }
                   cd _pkg
                   zip -r "../laricercadielisa-${VERSION}.zip" .
                   cd ..


### PR DESCRIPTION
## Problem

The Chrome extension release zip has been missing `_locales/` since the `rel-direct-tag.yml` workflow was introduced. This means `_locales/en/messages.json` and `_locales/it/messages.json` were never included, causing Chrome to reject the extension with:

> Error: Default locale was specified, but _locales subtree is missing.

Additionally, all 3 `actions/checkout` steps in this file used a bogus/non-existent SHA pinned as `# v6.0.2` (`de0fac2e4500dabe0009e67214ff5f5447ce83dd`).

## Root cause

`rel-direct-tag.yml` is the workflow that **actually** packages and publishes the release zip (its `create-release` job fires first on push→main). The packaging `run:` block copied `icons/` but never copied `_locales/`.

`rel-release.yml` was fixed in PR #36 but fires only after the broken zip was already published — too late.

## Changes

- **3× SHA fix**: Replace `de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2` with `11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2` in `tag-check`, `create-tag`, and `create-release` jobs
- **`_locales` copy**: Add guard check + `cp -r _locales _pkg/` + verification of both locale files before zipping

Closes #37